### PR TITLE
SUP-105 <allow CORS>

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const cors = require('cors');
 const app = express();
 const bodyParser = require("body-parser");
 const router = require("./routes");
@@ -8,6 +9,8 @@ require("./models/db");
 app.set("view engine", "ejs");
 
 app.use(express.json());
+
+app.use(cors()); // allow access from all domain
 
 // to be encoded into the URL-encoded format, allowing for
 // a JSON-like experience with URL-encoded.

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "bcrypt": "^5.1.0",
         "body-parser": "^1.20.1",
+        "cors": "^2.8.5",
         "ejs": "^3.1.8",
         "express": "^4.18.2",
         "mongoose": "^6.9.1"
@@ -1544,6 +1545,18 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -4252,6 +4265,15 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "debug": {
       "version": "2.6.9",

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "bcrypt": "^5.1.0",
     "body-parser": "^1.20.1",
+    "cors": "^2.8.5",
     "ejs": "^3.1.8",
     "express": "^4.18.2",
     "mongoose": "^6.9.1"


### PR DESCRIPTION
[backend] Allow CORS ( access able from all domain )
 - CORS stands for Cross Origin Resource Sharing, 
  and refers to the case where a resource is requested to a domain different from the current domain.
  For security reasons, browsers restrict CORS.