### PR TITLE
🐛 [BUG-34] Change today standard

### DIFF
--- a/app/src/recoil/selectors/filteredProgressState.js
+++ b/app/src/recoil/selectors/filteredProgressState.js
@@ -6,6 +6,11 @@ import {
 } from "../atoms";
 
 const today = new Date();
+const todayAtMidnight = new Date(
+  today.getFullYear(),
+  today.getMonth(),
+  today.getDate()
+);
 
 const getTimeFilteredList = (list, timeFilter) => {
   let condition = true;
@@ -29,7 +34,8 @@ const getTimeFilteredList = (list, timeFilter) => {
   }
   return list.filter((item) => {
     const startedDate = new Date(item.started_date);
-    const timeDiff = today.getTime() - startedDate.getTime();
+
+    const timeDiff = todayAtMidnight.getTime() - startedDate.getTime();
     dayDiff = Math.ceil(timeDiff / (1000 * 3600 * 24));
     // eslint-disable-next-line no-eval
     return eval(condition);


### PR DESCRIPTION
[Problem]
Show empty result when select "Today", "Yesterday" time filter.

[Reproduction Path]
Modified progress start_date to today/ yesterday in MongoDB.

[Cause]
1. Stored the date in MongoDB as UTC timezone.
2. Get today include current time.

[Fix]
1. Stored the date in MongoDB as Local timezone.
     ex) "started_date": "2023-03-23T23:00:00.000-07:00"
2. Get today's date as of midnight.

