### PR TITLE
BUG-88 <Display plural word depending value>

### DIFF
--- a/app/src/components/Chart/DonutChart.jsx
+++ b/app/src/components/Chart/DonutChart.jsx
@@ -17,7 +17,10 @@ const DonutChart = (props) => {
             <Bookmark fillColor={STATUS_COLOR[index]} />
             <section className="DonutChart-Legend-Text-Container">
               <p className="DonutChart-Legend-Main-Text">
-                {entry.value} trainee
+                {entry.value}{" "}
+                {entry.value === 0 || entry.value === 1
+                  ? "trainee"
+                  : "trainees"}
               </p>
               <p className="DonutChart-Legend-Sub-Text">{entry.name}</p>
             </section>


### PR DESCRIPTION
[Problem]
Trainees in analytics didn't display in plural
( https://supernova7.atlassian.net/browse/BUG-88 )

[Cause]
Didn't consider plural

[Fix]
Display plural "Trainee" word depending value