### PR TITLE
BUG-75 Lesson details "see more details" arrow is inverted

### DIFF
--- a/app/src/components/RecipeDetails.jsx
+++ b/app/src/components/RecipeDetails.jsx
@@ -102,9 +102,9 @@ const RecipeDetails = () => {
               <p className="Accordion-text">
                 {expanded === "panel" ? "See less details" : "See more details"}
                 {expanded === "panel" ? (
-                  <ArrowLineDown fillColor="#10494C" width="20" height="20" />
-                ) : (
                   <ArrowLineUp fillColor="#10494C" width="20" height="20" />
+                ) : (
+                  <ArrowLineDown fillColor="#10494C" width="20" height="20" />
                 )}
               </p>
             </AccordionSummary>


### PR DESCRIPTION
[Bug]
Arrow should be down before detail is shown and up when the detail is shown, vice versa.

[Fix]
Replace the arrow icons.