### PR TITLE
BUG-68 [Training] Wrong Wording

### DIFF
--- a/app/src/pages/dummy-steps.js
+++ b/app/src/pages/dummy-steps.js
@@ -52,7 +52,7 @@ const step = [
                     }]
                 },
             ],
-            note: "Talk to your manage in case you don’t have the necessary equipment."
+            note: "Talk to your manager in case you don’t have the necessary equipment."
         }, {
             substep_id: 2,
             title: "Grind Coffee",


### PR DESCRIPTION
[Bug]
- Talk to your manage in case you don’t have the necessary equipment. > should change to 
- Talk to your _manager_ in case you don’t have the necessary equipment.

[Fix]
- Fix typo