### PR TITLE
BUG-54 capitalize lesson  aeropress 

### DIFF
--- a/app/src/pages/dummy-lesson.js
+++ b/app/src/pages/dummy-lesson.js
@@ -32,7 +32,7 @@ const assigned_lessons = [{
 },
 {
     id: 4,
-    title: "aeropress",
+    title: "Aeropress",
     progress_status: 60,
     image_src: aeropress
 },


### PR DESCRIPTION
[Problem]
Lesson title "aeropress" was not captioned.
( https://supernova7.atlassian.net/browse/BUG-54)

[Cause]
Typo

[Fix]
Fix typo