### PR TITLE
Change backend server URL

### DIFF
--- a/app/src/utils/Constants.js
+++ b/app/src/utils/Constants.js
@@ -1,5 +1,4 @@
-export const BASE_URL =
-  "https://edspresso-backend-hosting-production.up.railway.app/api/v1";
+export const BASE_URL = "https://edspresso-backend-vercel.vercel.app/api/v1";
 
 // [Completed, In progress, Pending]
 export const STATUS_COLOR = ["#10494C", "#B84B11", "#FFDAAC"];


### PR DESCRIPTION
[DESC]
Change backend server hosting platform from Railway to Vercel.
Because Railway has time limitaiton in Free tier. ( 500h/1month )